### PR TITLE
Bug fix for overflow of total reputation in Reputation.sol contract

### DIFF
--- a/contracts/Reputation.sol
+++ b/contracts/Reputation.sol
@@ -9,7 +9,7 @@ import "./zeppelin-solidity/Ownable.sol";
 contract Reputation is Ownable {
 
     mapping (address => uint256) reputation;
-    uint256 totalReputation;
+    uint256 public totalReputation;
 
     function Reputation() {
         reputation[msg.sender] = 1;
@@ -20,8 +20,10 @@ contract Reputation is Ownable {
         return reputation[_owner];
     }
 
-	function set_reputation(address _account, uint256 _amount) onlyOwner {
+	function setReputation(address _account, uint256 _amount) onlyOwner {
+	    uint prevTotalReputation = totalReputation; 
         totalReputation = totalReputation - reputation[_account] + _amount;
+        if( ( _amount >= reputation[_account] ) && ( prevTotalReputation > totalReputation ) ) throw; // overflow 
 		reputation[_account] = _amount;
 	}
 }

--- a/contracts/Reputation.sol
+++ b/contracts/Reputation.sol
@@ -5,8 +5,9 @@ pragma solidity ^0.4.4;
 */
 
 import "./zeppelin-solidity/Ownable.sol";
+import "./zeppelin-solidity/SafeMath.sol";
 
-contract Reputation is Ownable {
+contract Reputation is Ownable, SafeMath {
 
     mapping (address => uint256) reputation;
     uint256 public totalReputation;
@@ -21,9 +22,8 @@ contract Reputation is Ownable {
     }
 
 	function setReputation(address _account, uint256 _amount) onlyOwner {
-	    uint prevTotalReputation = totalReputation; 
-        totalReputation = totalReputation - reputation[_account] + _amount;
-        if( ( _amount >= reputation[_account] ) && ( prevTotalReputation > totalReputation ) ) throw; // overflow 
+        totalReputation = safeAdd( safeSub(totalReputation, reputation[_account]),
+                                  _amount );
 		reputation[_account] = _amount;
 	}
 }

--- a/migrations/4_deploy_reputation.js
+++ b/migrations/4_deploy_reputation.js
@@ -1,0 +1,3 @@
+module.exports = function(deployer) {
+  deployer.deploy(Reputation);
+};

--- a/populus_tests/fixtures.py
+++ b/populus_tests/fixtures.py
@@ -4,9 +4,9 @@ import pytest
 def reputation(chain, accounts):
     # create a Reputation contract and seed it
     rep = chain.get_contract('Reputation')
-    rep.transact().set_reputation(accounts[0], 20000)
-    rep.transact().set_reputation(accounts[1], 10000)
-    rep.transact().set_reputation(accounts[2], 3141)
+    rep.transact().setReputation(accounts[0], 20000)
+    rep.transact().setReputation(accounts[1], 10000)
+    rep.transact().setReputation(accounts[2], 3141)
     return rep
 
 

--- a/populus_tests/test_reputation.py
+++ b/populus_tests/test_reputation.py
@@ -14,8 +14,8 @@ def test_sanity(chain, accounts, reputation):
     assert reputation.call().owner() == accounts[0]
 
     # we can set the reputation of accounts[1] and accounts[2]
-    reputation.transact().set_reputation(accounts[1], 10000)
-    reputation.transact().set_reputation(accounts[2], 3141)
+    reputation.transact().setReputation(accounts[1], 10000)
+    reputation.transact().setReputation(accounts[2], 3141)
 
     assert reputation.call().reputationOf(accounts[2]) == 3141
 
@@ -23,7 +23,7 @@ def test_sanity(chain, accounts, reputation):
 def test_type_errors(chain, accounts, reputation):
     # this should raise an error
     try:
-        reputation.transact().set_reputation(accounts[2], 3.14)
+        reputation.transact().setReputation(accounts[2], 3.14)
     except TypeError:
         pass
 
@@ -31,5 +31,5 @@ def test_type_errors(chain, accounts, reputation):
 def test_ownership(chain, accounts, reputation):
     # setting the rep from another account should fail
     with pytest.raises(ValueError):
-        reputation.transact(transaction={'from': accounts[3]}).set_reputation(accounts[3], 1234)
+        reputation.transact(transaction={'from': accounts[3]}).setReputation(accounts[3], 1234)
        

--- a/test/reputation.js
+++ b/test/reputation.js
@@ -1,0 +1,97 @@
+contract('Test Reputation', function(accounts) {
+
+
+  it("check premissionss", async function() {
+    let rep = Reputation.deployed();
+    await rep.setReputation(accounts[1], 1000, {from: accounts[0]});
+    // this tx should have no effect
+    await rep.setReputation(accounts[2], 1000, {from: accounts[1]});
+    let account0Rep = await rep.reputationOf(accounts[0]);    
+    let account1Rep = await rep.reputationOf(accounts[1]);
+    let account2Rep = await rep.reputationOf(accounts[2]);
+    let totalRep = await rep.totalReputation();
+    
+            
+    assert.equal(account1Rep, 1000, "account 1 reputation should be 1000");
+    assert.equal(account2Rep, 0, "account 2 reputation should be 0");
+    
+    assert.equal(parseInt(totalRep), parseInt(account0Rep) + parseInt(account1Rep), "total reputation should be sum of account0 and account1");
+  });
+
+  it("check total reputation", async function() {
+    let rep = Reputation.deployed();
+    await rep.setReputation(accounts[1], 1000, {from: accounts[0]});
+    await rep.setReputation(accounts[0], 2000, {from: accounts[0]});
+    await rep.setReputation(accounts[2], 3000, {from: accounts[0]});
+    await rep.setReputation(accounts[1], 500, {from: accounts[0]});        
+        
+    // this tx should have no effect
+    let account0Rep = await rep.reputationOf(accounts[0]);    
+    let account1Rep = await rep.reputationOf(accounts[1]);
+    let account2Rep = await rep.reputationOf(accounts[2]);
+    
+    assert.equal(account0Rep, 2000, "account 0 reputation should be 2000");    
+    assert.equal(account1Rep, 500, "account 1 reputation should be 500");    
+    assert.equal(account2Rep, 3000, "account 2 reputation should be 3000");
+    
+    let totalRep = await rep.totalReputation();
+    
+            
+    assert.equal(parseInt(totalRep), parseInt(account0Rep) + parseInt(account1Rep) + parseInt(account2Rep), "total reputation should be sum of accounts");
+  });
+
+
+  it("check total reputation overflow", async function() {
+    let rep = Reputation.deployed();
+    var BigNumber = require('bignumber.js');
+    var bigNum = ((new BigNumber(2)).toPower(255));
+
+    rep.setReputation(accounts[0], bigNum, {from: accounts[0]}).then(function(tx) {
+      // If this callback is called, the transaction was successfully processed.
+      // Note that Ether Pudding takes care of watching the network and triggering
+      // this callback.
+      assert(false, "overflow tx should fail");
+    }).catch(function(e) {
+      // error is expected
+    })    
+    
+    //let tx = await rep.setReputation(accounts[1], bigNum, {from: accounts[0]});    
+        
+    let totalRep = await rep.totalReputation();
+
+    assert( totalRep.greaterThanOrEqualTo(bigNum), "should not overflow" );        
+  });
+
+
+/*
+  it("abc", async function() {
+    let rep = Reputation.deployed();
+    let account0Rep = await rep.reputationOf(accounts[0]);
+    let totalRep = await rep.totalReputation();
+    assert.equal(account0Rep, 1, "as");
+    assert.equal(totalRep, 1, "as");    
+  });
+*/
+
+/*
+  it("should put 10000 reputation in the second account", function() {
+    var rep = Reputation.deployed();
+
+    console.log("sd");
+          console.log(rep);
+    console.log("sd2");              
+    rep.set_reputation(accounts[1], 1000, {from: accounts[0]}).then(function(tx_id) {
+    // If this callback is called, the transaction was successfully processed.
+    // check balance
+        console.log("hello");
+        rep.reputationOf.call(accounts[1]).then(function(reputation) {
+          assert.equal(reputation.valueOf(),1000, "1000 rep wasn't in the first account");
+        }).catch(function(e) {
+          assert(false,"reputationOf failed");
+        });      
+  }).catch(function(e) {
+    assert(false,"tx failed");
+  });
+  });
+  */
+});

--- a/test/reputation.js
+++ b/test/reputation.js
@@ -46,52 +46,32 @@ contract('Test Reputation', function(accounts) {
     var BigNumber = require('bignumber.js');
     var bigNum = ((new BigNumber(2)).toPower(255));
 
+    let tx = await rep.setReputation(accounts[1], bigNum, {from: accounts[0]});
+
+    let totalRepBefore = await rep.totalReputation();
+
+
+    const assertJump = require('./zeppelin-solidity/helpers/assertJump');
+    try {
+        let tx2 = await rep.setReputation(accounts[1], bigNum, {from: accounts[0]});
+    } catch(error) {
+        assertJump(error);
+    }
+
+    /*
+
     rep.setReputation(accounts[0], bigNum, {from: accounts[0]}).then(function(tx) {
       // If this callback is called, the transaction was successfully processed.
       // Note that Ether Pudding takes care of watching the network and triggering
       // this callback.
+      console.log("as");
       assert(false, "overflow tx should fail");
     }).catch(function(e) {
       // error is expected
-    })    
+    });*/    
     
-    //let tx = await rep.setReputation(accounts[1], bigNum, {from: accounts[0]});    
+    let totalRepAfter = await rep.totalReputation();
         
-    let totalRep = await rep.totalReputation();
-
-    assert( totalRep.greaterThanOrEqualTo(bigNum), "should not overflow" );        
+    assert( totalRepBefore.equals(totalRepAfter), "reputation should remain the same");
   });
-
-
-/*
-  it("abc", async function() {
-    let rep = Reputation.deployed();
-    let account0Rep = await rep.reputationOf(accounts[0]);
-    let totalRep = await rep.totalReputation();
-    assert.equal(account0Rep, 1, "as");
-    assert.equal(totalRep, 1, "as");    
-  });
-*/
-
-/*
-  it("should put 10000 reputation in the second account", function() {
-    var rep = Reputation.deployed();
-
-    console.log("sd");
-          console.log(rep);
-    console.log("sd2");              
-    rep.set_reputation(accounts[1], 1000, {from: accounts[0]}).then(function(tx_id) {
-    // If this callback is called, the transaction was successfully processed.
-    // check balance
-        console.log("hello");
-        rep.reputationOf.call(accounts[1]).then(function(reputation) {
-          assert.equal(reputation.valueOf(),1000, "1000 rep wasn't in the first account");
-        }).catch(function(e) {
-          assert(false,"reputationOf failed");
-        });      
-  }).catch(function(e) {
-    assert(false,"tx failed");
-  });
-  });
-  */
 });


### PR DESCRIPTION
The following was done:
1. In Reputation.sol:
i. Changed `set_reputation` name to `setReputation` as the previous name does not fit the naming conventions.
ii. Added a check for overflow in `setReputation`. If an overflow is detected, an exception is thrown.
iii. Changed `totalReputation` storage variable to `public`. This is needed for testing. Beside what is the point of defining it as an internal variable if the contract does not use it?

2. Testing: added truffle tests (js files).
3. Updated populus_tests files to call `setReputation` instead of `set_reputation`.