### PR TITLE
Fixes to #94 and #97

### DIFF
--- a/docs/library/README.md
+++ b/docs/library/README.md
@@ -1,7 +1,7 @@
 
 # DAOSTACK library
 
-Work in progress.
+Work in progress.  Install via `npm install emergent-arc`.
 
 ## API
 
@@ -10,7 +10,7 @@ Work in progress.
 ## Example Session
 [next examples are not all working yet, but this is what is should/could look like]
 
-    import { Organization } from '/path/to/daostack.js';
+    import { Organization } from 'emergent-arc';
 
 create an Organization from zero:
 

--- a/lib/arc.js
+++ b/lib/arc.js
@@ -1,9 +1,8 @@
-export * from './daostack.js';
-export * from './globalconstraintregistrar.js';
 export * from './organization.js';
+export * from './globalconstraintregistrar.js';
+export * from './upgradescheme.js';
 export * from './schemeregistrar.js';
 export * from './simplecontributionscheme.js';
-export * from './simplevote.js';
 export * from './utils.js';
 import  { getWeb3 } from './utils.js';
 import { getSettings } from './settings.js';
@@ -30,6 +29,6 @@ export function configure(options) {
 }
 
 /**
- * returns addresses and TruffleContracts of universal contracts.
+ * returns addresses and TruffleContracts of universal schemes.
  */
-export function getUniversalContracts() { return getSettings(); }
+export async function getUniversalSchemes() { return (await getSettings()).daostackContracts; }

--- a/lib/daostack.js
+++ b/lib/daostack.js
@@ -1,60 +1,14 @@
 import  { Organization } from './organization.js';
 import { getDefaultAccount, requireContract } from './utils.js';
 
-const SchemeRegistrar = requireContract("SchemeRegistrar");
-const UpgradeScheme = requireContract("UpgradeScheme");
-const DAOToken = requireContract("DAOToken");
-
-
 /**
+ * DEPRECATED.  See arc.js
  * DAOStack library
  *
  */
 // TODO: documentation!
 
 const daostack = (function() {
-
-    async function createSchemeRegistrar(opts={}) {
-        // TODO: remove this function, use SchemeREgistrar.new(..) instead
-        // TODO: provide options to use an existing token or specifiy the new token
-        const defaults = {
-            fee: 0, // the fee to use this scheme
-            beneficiary: getDefaultAccount(),
-            tokenAddress: undefined, // the address of a token to use
-        };
-
-        const options = Object.assign(defaults, opts);
-
-        if (options.tokenAddress == undefined) {
-            let token = await DAOToken.new('schemeregistrartoken', 'SRT');
-            options.tokenAddress = token.address;
-
-        }
-        SchemeRegistrar.setProvider(web3.currentProvider);
-        return SchemeRegistrar.new(options.tokenAddress, options.fee, options.beneficiary);
-    }
-
-    async function createUpgradeScheme(opts={}) {
-        // TODO: remove this function, use UpgradeScheme.new(..) instead
-        // TODO: provide options to use an existing token or specifiy the new token
-        const defaults = {
-            fee: 0, // the fee to use this scheme
-            beneficiary: getDefaultAccount(),
-            tokenAddress: undefined, // the address of a token to use
-        };
-
-        const options = Object.assign(defaults, opts);
-
-        let token;
-        if (options.tokenAddress == undefined) {
-            token = await DAOToken.new('schemeregistrartoken', 'SRT');
-
-        } else {
-            token = await DAOToken.at(options.tokenAddress);
-        }
-
-        return UpgradeScheme.new(token.address, options.fee, options.beneficiary);
-    }
 
     // async function _checkForNecessaryFunds() {
     //   // TODO: this is not working at all yet: the idea is that we check some precodnitions
@@ -83,8 +37,6 @@ const daostack = (function() {
     // }
 
     return  {
-        createSchemeRegistrar,
-        createUpgradeScheme,
     };
 
 }());

--- a/lib/daostack.js
+++ b/lib/daostack.js
@@ -1,5 +1,4 @@
 import  { Organization } from './organization.js';
-import { getDefaultAccount, requireContract } from './utils.js';
 
 /**
  * DEPRECATED.  See arc.js

--- a/lib/globalconstraintregistrar.js
+++ b/lib/globalconstraintregistrar.js
@@ -29,4 +29,12 @@ export class GlobalConstraintRegistrar extends ExtendTruffleContract(SolidityGlo
     contract = await SolidityGlobalConstraintRegistrar.new(token.address, options.fee, options.beneficiary);
     return new this(contract);
   }
+
+  async setParams(params) {
+    return await this._setParameters(params.voteParametersHash, params.votingMachine);
+  }
+  
+  getDefaultPermissions(overrideValue) {
+    return overrideValue || '0x00000005';
+  }  
 }

--- a/lib/organization.js
+++ b/lib/organization.js
@@ -9,11 +9,11 @@ const GenesisScheme = requireContract("GenesisScheme");
 const Reputation = requireContract("Reputation");
 const SimpleICO = requireContract("SimpleICO");
 // const SimpleVote = requireContract("SimpleVote");
-import { GlobalConstraintRegistrar } from   '../lib/globalconstraintregistrar.js';
+// import { GlobalConstraintRegistrar } from   '../lib/globalconstraintregistrar.js';
 const AbsoluteVote = requireContract("AbsoluteVote");
 import { SimpleContributionScheme } from   '../lib/simplecontributionscheme.js';
 const TokenCapGC = requireContract("TokenCapGC");
-import { UpgradeScheme } from   '../lib/upgradescheme.js';
+// import { UpgradeScheme } from   '../lib/upgradescheme.js';
 
 import { getSettings } from './settings.js';
 import { getValueFromLogs, NULL_ADDRESS } from './utils.js';

--- a/lib/organization.js
+++ b/lib/organization.js
@@ -13,7 +13,7 @@ import { GlobalConstraintRegistrar } from   '../lib/globalconstraintregistrar.js
 const AbsoluteVote = requireContract("AbsoluteVote");
 import { SimpleContributionScheme } from   '../lib/simplecontributionscheme.js';
 const TokenCapGC = requireContract("TokenCapGC");
-const UpgradeScheme = requireContract("UpgradeScheme");
+import { UpgradeScheme } from   '../lib/upgradescheme.js';
 
 import { getSettings } from './settings.js';
 import { getValueFromLogs, NULL_ADDRESS } from './utils.js';
@@ -41,6 +41,7 @@ export class Organization {
     // TODO: orgName, tokenName and tokenSymbol should be required - implement this
     // QUESTION: should we add options to deploy with existing tokens or rep?
     const settings = await getSettings();
+
     const defaults = {
         orgName: null,
         tokenName: null,
@@ -49,6 +50,8 @@ export class Organization {
         votingMachine: settings.daostackContracts.AbsoluteVote.address,
         votePrec: 50,
         ownerVote: true,
+        orgNativeTokenFee: 0, // used for SimpleContributionScheme
+        schemeNativeTokenFee: 0, // used for SimpleContributionScheme
         genesisScheme: settings.daostackContracts.GenesisScheme.address,
         schemes: [
           {
@@ -106,42 +109,24 @@ export class Organization {
     let initialSchemesTokenAddresses = [];
     let initialSchemesFees = [];
     let initialSchemesPermissions = [];
-    let scheme;
-    // const initalSchemesPermissions = ['0x00000003', '0x00000009', '0x00000005'];
 
-    const schemes = options.schemes;
-    for (let i=0; i < schemes.length; i = i + 1) {
-      if (schemes[i].contract === CONTRACT_SCHEMEREGISTRAR) {
-        scheme = await SchemeRegistrar.at(schemes[i].address);
-        await scheme.setParameters(voteParametersHash, voteParametersHash, org.votingMachine.address);
-        initialSchemesAddresses.push(schemes[i].address);
-        initialSchemesParams.push(await scheme.getParametersHash(voteParametersHash, voteParametersHash, org.votingMachine.address));
+    for (let optionScheme of options.schemes) {
+
+        var arcSchemeInfo = settings.daostackContracts[optionScheme.contract];
+        var scheme = await arcSchemeInfo.contract.at(optionScheme.address || arcSchemeInfo.address);
+
+        const paramsHash = await scheme.setParams({
+          voteParametersHash: voteParametersHash,
+          votingMachine: org.votingMachine.address,
+          orgNativeTokenFee: options.orgNativeTokenFee,
+          schemeNativeTokenFee: options.schemeNativeTokenFee
+        });
+        
+        initialSchemesAddresses.push(scheme.address);
+        initialSchemesParams.push(paramsHash);
         initialSchemesTokenAddresses.push(await scheme.nativeToken());
         initialSchemesFees.push(await scheme.fee());
-        initialSchemesPermissions.push('0x00000003');
-      }
-
-      if (schemes[i].contract === CONTRACT_UPGRADESCHEME) {
-        // TODO: these are specific configuation options that should be settable in the options above
-        scheme = await UpgradeScheme.at(schemes[i].address);
-        await scheme.setParameters(voteParametersHash, org.votingMachine.address);
-        initialSchemesAddresses.push(schemes[i].address);
-        initialSchemesParams.push(await scheme.getParametersHash(voteParametersHash, org.votingMachine.address));
-        initialSchemesTokenAddresses.push(await scheme.nativeToken());
-        initialSchemesFees.push(await scheme.fee());
-        initialSchemesPermissions.push('0x00000009');
-      }
-
-      if (schemes[i].contract === CONTRACT_GLOBALCONSTRAINTREGISTRAR) {
-        // TODO: these are specific configuation options that should be settable in the options above
-        scheme = await GlobalConstraintRegistrar.at(schemes[i].address);
-        await scheme.setParameters(voteParametersHash, org.votingMachine.address);
-        initialSchemesAddresses.push(schemes[i].address);
-        initialSchemesParams.push(await scheme.getParametersHash(voteParametersHash, org.votingMachine.address));
-        initialSchemesTokenAddresses.push(await scheme.nativeToken());
-        initialSchemesFees.push(await scheme.fee());
-        initialSchemesPermissions.push('0x00000005');
-      }
+        initialSchemesPermissions.push(scheme.getDefaultPermissions(/* supply options.permissions here? */));
     }
 
     // register the schemes with the organization
@@ -231,11 +216,12 @@ export class Organization {
 
     // we derive the type of scheme from its permissions, which is at most approximate.
     for (i=0; i < addresses.length; i++) {
+        permissions = await controller.getSchemePermissions(addresses[i]);
+
         scheme = {
           address: addresses[i],
           permissions: permissions,
         };
-        permissions = await controller.getSchemePermissions(addresses[i]);
         
         if (parseInt(permissions) === 0) {
             // contract = 'unregistered' - we ignore it
@@ -269,7 +255,7 @@ export class Organization {
     const contractInfo = settings.daostackContracts[contract];
     // check if indeed the registrar is registered as a scheme on  the controller
     const isSchemeRegistered = await this.controller.isSchemeRegistered(contractInfo.address);
-    assert.equal(isSchemeRegistered, true);
+    assert.equal(isSchemeRegistered, true, `${contract} is not registered with the controller`);
 
     return contractInfo.contract.at(contractInfo.address);
   }
@@ -282,7 +268,7 @@ export class Organization {
 
     // check if indeed the registrar is registered as a scheme on  the controller
     const isSchemeRegistered = await controller.isSchemeRegistered(scheme.address);
-    assert.equal(isSchemeRegistered, true);
+    assert.equal(isSchemeRegistered, true, `${contract} is not registered with the controller`);
 
     // check if the controller is registered (has paid the fee)
     const isControllerRegistered = await scheme.isRegistered(avatar.address);

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -2,17 +2,14 @@ import { requireContract } from './utils.js';
 
 // TODO: these are settings for testing. Need some way to switch to "production settings"
 const GenesisScheme = requireContract("GenesisScheme");
-//const GlobalConstraintRegistrar = requireContract("GlobalConstraintRegistrar"); 
 import { GlobalConstraintRegistrar } from   '../lib/globalconstraintregistrar.js';
-const SchemeRegistrar = requireContract("SchemeRegistrar");
-// const SimpleContributionScheme = requireContract("SimpleContributionScheme");
+import { SchemeRegistrar } from   '../lib/schemeregistrar.js';
 import { SimpleContributionScheme } from   '../lib/simplecontributionscheme.js';
 const SimpleICO = requireContract("SimpleICO");
 const SimpleVote = requireContract("SimpleVote");
 const AbsoluteVote = requireContract("AbsoluteVote");
 const TokenCapGC = requireContract("TokenCapGC");
-const UpgradeScheme = requireContract("UpgradeScheme");
-const OrganizationRegister = requireContract("OrganizationRegister");
+import { UpgradeScheme } from   '../lib/upgradescheme.js';
 
 const getSettings = async function(){
   const contributionScheme = await SimpleContributionScheme.deployed();
@@ -23,7 +20,6 @@ const getSettings = async function(){
   const tokenCapGC = await TokenCapGC.deployed();
   const upgradeScheme = await UpgradeScheme.deployed();
   const simpleVote = await SimpleVote.deployed();
-  const organizationRegister = await OrganizationRegister.deployed();
   const absoluteVote = await AbsoluteVote.deployed();
 
   return {
@@ -64,11 +60,7 @@ const getSettings = async function(){
       SimpleVote: {
         contract: SimpleVote,
         address: simpleVote.address,
-      },
-      OrganizationRegister: {
-        contract: OrganizationRegister,
-        address: organizationRegister.address,
-      },
+      }
     }
   };
 };

--- a/lib/simplecontributionscheme.js
+++ b/lib/simplecontributionscheme.js
@@ -1,12 +1,35 @@
 "use strict";
-
 const dopts = require('default-options');
 
-import { ExtendTruffleContract, getValueFromLogs, requireContract } from './utils.js';
+import { getDefaultAccount, ExtendTruffleContract, getValueFromLogs, requireContract } from './utils.js';
 
 const SoliditySimpleContributionScheme = requireContract("SimpleContributionScheme");
+const DAOToken = requireContract("DAOToken");
 
 class SimpleContributionScheme extends ExtendTruffleContract(SoliditySimpleContributionScheme) {
+
+  static async new(opts={}) {
+    // TODO: provide options to use an existing token or specifiy the new token
+    const defaults = {
+        tokenAddress: null, // the address of a token to use
+        fee: 0, // the fee to use this scheme
+        beneficiary: getDefaultAccount(),
+    };
+
+    const options = dopts(opts, defaults);
+
+    let token;
+    if (options.tokenAddress == null) {
+        token = await DAOToken.new('schemeregistrartoken', 'STK');
+      // TODO: or is it better to throw an error?
+      // throw 'A tokenAddress must be provided';
+    } else {
+        token = await DAOToken.at(options.tokenAddress);
+    }
+
+    contract = await SoliditySimpleContributionScheme.new(token.address, options.fee, options.beneficiary);
+    return new this(contract);
+  }
 
   async submitContribution(opts={}) {
     const defaults = {
@@ -52,6 +75,14 @@ class SimpleContributionScheme extends ExtendTruffleContract(SoliditySimpleContr
         options.beneficiary // address _beneficiary
     );
     return getValueFromLogs(tx, '_proposalId');
+  }
+
+  async setParams(params) {
+    return await this._setParameters(params.orgNativeTokenFee, params.schemeNativeTokenFee, params.voteParametersHash, params.votingMachine);
+  }
+
+  getDefaultPermissions(overrideValue) {
+    return overrideValue || '0x00000001';
   }
 }
 

--- a/lib/upgradescheme.js
+++ b/lib/upgradescheme.js
@@ -3,37 +3,38 @@ const dopts = require('default-options');
 
 import { getDefaultAccount, ExtendTruffleContract, requireContract } from './utils.js';
 
-const SoliditySchemeRegistrar = requireContract("SchemeRegistrar");
+const SolidityUpgradeScheme = requireContract("UpgradeScheme");
 const DAOToken = requireContract("DAOToken");
 
-export class SchemeRegistrar extends ExtendTruffleContract(SoliditySchemeRegistrar) {
+export class UpgradeScheme extends ExtendTruffleContract(SolidityUpgradeScheme) {
   static async new(opts={}) {
     // TODO: provide options to use an existing token or specifiy the new token
     const defaults = {
         fee: 0, // the fee to use this scheme
         beneficiary: getDefaultAccount(),
-        tokenAddress: undefined, // the address of a token to use
+        tokenAddress: null, // the address of a token to use
     };
 
     const options = dopts(opts, defaults);
 
     let token;
-    if (options.tokenAddress == undefined) {
+    if (options.tokenAddress == null) {
         token = await DAOToken.new('schemeregistrartoken', 'SRT');
-
+      // TODO: or is it better to throw an error?
+      // throw 'A tokenAddress must be provided';
     } else {
         token = await DAOToken.at(options.tokenAddress);
     }
 
-    contract = await SoliditySchemeRegistrar.new(token.address, options.fee, options.beneficiary);
+    contract = await SolidityUpgradeScheme.new(token.address, options.fee, options.beneficiary);
     return new this(contract);
   }
 
   async setParams(params) {
-     return await this._setParameters(params.voteParametersHash, params.voteParametersHash, params.votingMachine);
+    return await this._setParameters(params.voteParametersHash, params.votingMachine);
    }
-  
+
   getDefaultPermissions(overrideValue) {
-    return overrideValue || '0x00000003';
+    return overrideValue || '0x00000009';
   }
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -191,4 +191,37 @@ export const ExtendTruffleContract = (superclass) => class {
   static async deployed() {
     return new this(await superclass.deployed());
   }
+
+  /**
+   * Call setParameters on this scheme.
+   * Returns promise of parameters hash.
+   * If there are any parameters, then this function must be overridden by the subclass to provide them.
+   * @param overrides -- object with properties whose names are expected by the scheme to correspond to parameters.  Overrides the defaults.
+   * 
+   * Should have the following properties:
+   *  
+   *  for all:
+   *    voteParametersHash
+   *    votingMachine -- address
+   * 
+   *  for SimpleContributionScheme:
+   *    orgNativeTokenFee -- number
+   *    schemeNativeTokenFee -- number
+   */
+  async setParams(params) {
+    return await '';
+  }
+
+  async _setParameters() {
+     const parametersHash = await this.contract.getParametersHash(...arguments);
+    await this.contract.setParameters(...arguments);
+    return parametersHash;
+  }
+
+  /**
+   * The subclass must override this for there to be any permissions at all, unless caller provides a value.
+   */
+  getDefaultPermissions(overrideValue) {
+    return overrideValue || '0x00000000';
+  }
 };

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -208,6 +208,7 @@ export const ExtendTruffleContract = (superclass) => class {
    *    orgNativeTokenFee -- number
    *    schemeNativeTokenFee -- number
    */
+  // eslint-disable-next-line no-unused-vars
   async setParams(params) {
     return await '';
   }

--- a/migrations/2_deploy_DAOstack.js
+++ b/migrations/2_deploy_DAOstack.js
@@ -102,7 +102,7 @@ module.exports = async function(deployer) {
 
       var schemesArray = [schemeRegistrarInst.address, globalConstraintRegistrarInst.address, upgradeSchemeInst.address];
       var paramsArray = [schemeRegisterParams, schemeGCRegisterParams, schemeUpgradeParams];
-      var permissionArray = [3, 5, 9];
+      var permissionArray = ['0x00000003', '0x00000005', '0x00000009'];
       var tokenArray = [tokenAddress, tokenAddress, tokenAddress];
       var feeArray = [UniversalRegisterFee, UniversalRegisterFee, UniversalRegisterFee];
 
@@ -121,11 +121,9 @@ module.exports = async function(deployer) {
       await globalConstraintRegistrarInst.registerOrganization(AvatarInst.address);
       await upgradeSchemeInst.registerOrganization(AvatarInst.address);
 
-
-      deployer.deploy(SimpleICO, tokenAddress, UniversalRegisterFee, avatarAddress);
-      deployer.deploy(OrganizationRegister, tokenAddress, UniversalRegisterFee, avatarAddress);
+      await deployer.deploy(SimpleICO, tokenAddress, UniversalRegisterFee, avatarAddress);
+      await deployer.deploy(SimpleContributionScheme, tokenAddress, 0, avatarAddress);
     });
 
-    deployer.deploy(SimpleContributionScheme);
-    deployer.deploy(TokenCapGC);
+    await deployer.deploy(TokenCapGC);
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "emergent-arc",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Building DAOs",
   "main": "lib/arc.js",
   "directories": {

--- a/test/globalconstraintregistrar.js
+++ b/test/globalconstraintregistrar.js
@@ -67,7 +67,8 @@ contract('GlobalConstraintRegistrar', function(accounts) {
     const parametersForVotingInGCR = await gcr.parameters(parametersForGCR);
 
     // the info we just got consists of paramsHash and permissions
-    // const gcrPermissionsOnOrg = await organization.controller.getSchemePermissions(gcr.address);
+    const gcrPermissionsOnOrg = await organization.controller.getSchemePermissions(gcr.address);
+    assert.equal(gcrPermissionsOnOrg, '0x00000005');
 
     // the voting machine used in this GCR is the same as the voting machine of the organization
     assert.equal(organization.votingMachine.address, parametersForVotingInGCR[1]);

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -1,6 +1,5 @@
 const DAOToken = artifacts.require("./DAOToken.sol");
 
-import { daostack } from '../lib/daostack.js';
 import { SchemeRegistrar } from   '../lib/schemeregistrar.js';
 
 contract('SchemeRegistrar', function(accounts) {

--- a/test/schemeregistrar.js
+++ b/test/schemeregistrar.js
@@ -1,12 +1,17 @@
 const DAOToken = artifacts.require("./DAOToken.sol");
 
 import { daostack } from '../lib/daostack.js';
+import { SchemeRegistrar } from   '../lib/schemeregistrar.js';
 
 contract('SchemeRegistrar', function(accounts) {
 
-  it("the daostack.createSchemeRegistrar function should work as expected with default values", async function() {
+  it("schemeRegistrar.new should work as expected with default values", async function() {
     // create a schemeRegistrar
-    const registrar = await daostack.createSchemeRegistrar();
+    const registrar = await SchemeRegistrar.new({
+        fee: undefined,
+        beneficiary: undefined,
+        tokenAddress: undefined
+    });
 
     // because the registrar is constructed without a token address, it should have
     // created a new DAOToken - we check if it works as expected
@@ -21,11 +26,11 @@ contract('SchemeRegistrar', function(accounts) {
     assert.equal(balance.valueOf(), 1000 * Math.pow(10, 18));
   });
 
-  it("the daostack.createSchemeRegistrar function should work as expected with non-default values", async function() {
+  it("schemeRegistrar.new should work as expected with non-default values", async function() {
     // create a schemeRegistrar, passing some options
     const token = await DAOToken.new();
 
-    const registrar = await daostack.createSchemeRegistrar({
+    const registrar = await  SchemeRegistrar.new({
         tokenAddress:token.address,
         fee: 3e18,
         beneficiary: accounts[1]

--- a/test/simplecontribution.js
+++ b/test/simplecontribution.js
@@ -1,4 +1,5 @@
 import { SimpleContributionScheme } from '../lib/simplecontributionscheme.js';
+const DAOToken = artifacts.require("./DAOToken.sol");
 import * as helpers from './helpers';
 
 const SoliditySimpleContributionScheme = artifacts.require("./SimpleContributionScheme.sol");
@@ -157,12 +158,14 @@ contract('SimpleContribution scheme', function(accounts) {
   it('Can set and get parameters', async function() {
       let params;
 
-      // create a contribution Scheme
-      const contributionScheme = await SimpleContributionScheme.new(
-        helpers.SOME_ADDRESS,
-        0, // register with 0 fee
-        accounts[0],
-      );
+      const token = await DAOToken.new();
+
+    // create a contribution Scheme
+      const contributionScheme = await SimpleContributionScheme.new({
+        tokenAddress: token.address,
+        fee: 0, // register with 0 fee
+        beneficiary: accounts[1],
+      });
 
       const contributionSchemeParamsHash = await contributionScheme.getParametersHash(
         0,

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,5 +1,6 @@
 "use strict";
 import { ExtendTruffleContract } from '../lib/utils.js';
+import * as helpers from './helpers';
 
 const SoliditySimpleContributionScheme = artifacts.require("./SimpleContributionScheme.sol");
 
@@ -14,6 +15,16 @@ class SimpleContributionScheme extends ExtendTruffleContract(SoliditySimpleContr
     // console.log('submitContribution() called');
     return 'abc';
   }
+
+
+  async setParams(params) {
+    return await this._setParameters(params.orgNativeTokenFee, params.schemeNativeTokenFee, params.voteParametersHash, params.votingMachine);
+   }
+
+  getDefaultPermissions(overrideValue) {
+    return overrideValue || '0x00000009';
+  }
+
 }
 
 
@@ -26,6 +37,8 @@ contract('ExtendTruffleContract', function() {
     assert.equal(x.foo(), 'bar');
     assert.equal(x.submitContribution(), 'abc');
     assert.equal(await x.nativeToken(), await x.contract.nativeToken());
+    assert.equal(await x.setParams({ orgNativeTokenFee: 0, schemeNativeTokenFee: 0, voteParametersHash: helpers.SOME_HASH, votingMachine: helpers.SOME_ADDRESS }), '0xb6660b30e997e8e19cd58699fbf81c41450f200dbcb9f6a85c07b08483c86ee9');
+    assert.equal(x.getDefaultPermissions(), '0x00000009');
 
     x = await SimpleContributionScheme.at((await SoliditySimpleContributionScheme.deployed()).address);
     assert.isOk(x.nativeToken());


### PR DESCRIPTION
#94 -- `Organization.getSchemes` is not properly returning scheme permissions 
#97 -- `Organization.new` does not know how to add SimpleContributionScheme 

Note that `SimpleContributionScheme` is now deployed with the standard token and beneficiary, and zero fee. This was necessary to enable both tests to work and Alchemy to be able to add the scheme at DAO creation time.

Each of the four major schemes now have a javascript class and consistent interface associated with them to facilitate `Organization.new` now, and other functions later, being agnostic as to what schemes they are working with.