### PR TITLE
#127 SimpleContributionScheme.submitContribution()` crashes getValueFromLogs

### DIFF
--- a/dist/simplecontributionscheme.js
+++ b/dist/simplecontributionscheme.js
@@ -75,7 +75,7 @@ var SimpleContributionScheme = function (_ExtendTruffleContrac) {
             options.externalTokenReward, // uint _externalTokenReward,
             options.beneficiary // address _beneficiary
             );
-            return (0, _utils.getValueFromLogs)(tx, '_proposalId');
+            return tx;
         }
     }, {
         key: 'setParams',

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -47,7 +47,7 @@ function requireContract(contractName) {
       _contract.setProvider(myWeb3.currentProvider);
       _contract.defaults({
         from: getDefaultAccount(),
-        gas: 0x455510
+        gas: 0x442168
       });
       return _contract;
     } catch (ex) {

--- a/dist/wallet.js
+++ b/dist/wallet.js
@@ -41,11 +41,18 @@ var Wallet = exports.Wallet = function () {
     _classCallCheck(this, Wallet);
   }
 
+  // Create a new wallet and encrypt it with password
+  // The wallet will be generated deterministically from a mnemonic created using bip39
+
+
   _createClass(Wallet, [{
     key: 'getEncryptedJSON',
     value: function getEncryptedJSON() {
       return this.encryptedJSON;
     }
+
+    // TODO: convert to ether?
+
   }, {
     key: 'getEtherBalance',
     value: async function getEtherBalance() {
@@ -88,6 +95,9 @@ var Wallet = exports.Wallet = function () {
       wallet.encryptedJSON = await wallet.wallet.encrypt(password, progressCallback);
       return wallet;
     }
+
+    // Unencrypt an encrypted wallet
+
   }, {
     key: 'fromEncrypted',
     value: async function fromEncrypted(encryptedJSON, password, progressCallback) {
@@ -95,6 +105,20 @@ var Wallet = exports.Wallet = function () {
       wallet.wallet = await ethers.Wallet.fromEncryptedWallet(encryptedJSON, password, progressCallback);
       wallet.wallet.provider = provider;
       wallet.encryptedJSON = encryptedJSON;
+      return wallet;
+    }
+
+    // Recover a wallet from a mnemonic and then encrypt it with a new password
+    // TODO: what happens with an invalid mnemonic?
+
+  }, {
+    key: 'fromMnemonic',
+    value: async function fromMnemonic(mnemonic, password, progressCallback) {
+      var wallet = new Wallet();
+      wallet.wallet = ethers.Wallet.fromMnemonic(mnemonic);
+      wallet.mnemonic = mnemonic;
+      wallet.wallet.provider = provider;
+      wallet.encryptedJSON = await wallet.wallet.encrypt(password, progressCallback);
       return wallet;
     }
   }]);

--- a/lib/simplecontributionscheme.js
+++ b/lib/simplecontributionscheme.js
@@ -1,7 +1,7 @@
 "use strict";
 const dopts = require('default-options');
 
-import { getDefaultAccount, ExtendTruffleContract, getValueFromLogs, requireContract } from './utils.js';
+import { getDefaultAccount, ExtendTruffleContract, requireContract } from './utils.js';
 
 const SoliditySimpleContributionScheme = requireContract("SimpleContributionScheme");
 const DAOToken = requireContract("DAOToken");

--- a/lib/simplecontributionscheme.js
+++ b/lib/simplecontributionscheme.js
@@ -74,7 +74,7 @@ class SimpleContributionScheme extends ExtendTruffleContract(SoliditySimpleContr
         options.externalTokenReward, // uint _externalTokenReward,
         options.beneficiary // address _beneficiary
     );
-    return getValueFromLogs(tx, '_proposalId');
+    return tx;
   }
 
   async setParams(params) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "emergent-arc",
-  "version": "0.0.9",
+  "name": "daostack-arc",
+  "version": "0.0.0-alpha.9",
   "lockfileVersion": 1,
   "dependencies": {
     "abbrev": {


### PR DESCRIPTION
#127 return tx instead of trying to parse it for the proposal id

Note some of the changes in `dist` are due to other PRs not having done an `npm run build` (perhaps from before the dist folder existed).