### PR TITLE
Remove "lock" from daotoken

### DIFF
--- a/contracts/controller/DAOToken.sol
+++ b/contracts/controller/DAOToken.sol
@@ -1,29 +1,21 @@
 pragma solidity ^0.4.18;
 
 import "zeppelin-solidity/contracts/token/MintableToken.sol";
+import "zeppelin-solidity/contracts/token/BurnableToken.sol";
 import "zeppelin-solidity/contracts/lifecycle/Destructible.sol";
-import "zeppelin-solidity/contracts/math/SafeMath.sol";
+
 
 
 /**
  * @title DAOToken, base on zeppelin contract.
- * @dev ERC20 comptible token. It is a mintable, lockable, burnable token.
+ * @dev ERC20 comptible token. It is a mintable, destructable, burnable token.
  */
 
-contract DAOToken is MintableToken, Destructible {
-    using SafeMath for uint;
-
-    event TokenLock(address indexed user, uint value);
-    event Burn(uint value);
-
-    struct Lock {
-        uint lockedAmount;
-        uint releaseBlock;
-    }
+contract DAOToken is MintableToken,Destructible,BurnableToken {
 
     string public name;
     string public symbol;
-    uint public decimals = 18;
+    uint public constant DECIMAL = 18;
 
     /**
      * @dev the constructor takes a token name and a symbol
@@ -31,65 +23,5 @@ contract DAOToken is MintableToken, Destructible {
     function DAOToken(string _name, string _symbol) public {
         name = _name;
         symbol = _symbol;
-    }
-
-    // Locking mapping:
-    mapping(address => Lock) lockBalances;
-
-    function lock(uint _value, uint _releaseBlock) public {
-        lockInternal(msg.sender, _value, _releaseBlock);
-    }
-
-    function mintLocked(address _to, uint _amount, uint _releaseBlock) public returns(bool res) {
-        res = (super.mint(_to, _amount));
-        lockInternal(_to, _amount, _releaseBlock);
-    }
-
-    // Rewriting the function to check for locking and burn tokens of the contract itself:
-    function transfer(address _to, uint _value) public returns(bool res) {
-        // Check for locking:
-        if (lockBalances[msg.sender].releaseBlock > block.number)
-            require(balances[msg.sender].sub(_value) >= lockBalances[msg.sender].lockedAmount);
-
-        res = (super.transfer(_to, _value));
-
-        if (_to == address(this))
-            burnContractTokens();
-    }
-
-    // Rewriting the function to check for locking and burn tokens of the contract itself:
-    function transferFrom(address _from, address _to, uint _value) public returns(bool res) {
-        // Check for locking:
-        if (lockBalances[_from].releaseBlock > block.number)
-            require(balances[_from].sub(_value) >= lockBalances[_from].lockedAmount);
-
-        res = (super.transferFrom(_from, _to, _value));
-
-        if (_to == address(this)) {
-            burnContractTokens();
-        }
-    }
-
-    // The token contract should not hold its own tokens, allow anyont to burn its balance:
-    function burnContractTokens() public {
-        totalSupply = totalSupply.sub(balances[this]);
-        balances[this] = 0;
-        Burn(balances[this]);
-    }
-
-    function lockInternal(address agent, uint _value, uint _releaseBlock) internal {
-        // Sanity check:
-        require(_value != 0);
-        require(_value <= balances[agent]);
-
-        // Check if user has locked funds, and verify the change is legit:
-        if (lockBalances[agent].releaseBlock > block.number) {
-            require(_value >= lockBalances[agent].lockedAmount);
-            require(_releaseBlock >= lockBalances[agent].releaseBlock);
-        }
-
-        lockBalances[agent].lockedAmount = _value;
-        lockBalances[agent].releaseBlock = _releaseBlock;
-        TokenLock(agent, _value);
     }
 }

--- a/test/daotoken.js
+++ b/test/daotoken.js
@@ -110,6 +110,26 @@ contract('DAOToken', accounts => {
         assert.equal(totalSupply.toNumber(), 0);
     });
 
+    it("burn", async () => {
+        const token = await DAOToken.new();
+
+        await token.mint(accounts[1], 1000, { from: accounts[0] });
+
+        var amount = await token.balanceOf(accounts[1]);
+
+        assert.equal(amount.toNumber(), 1000);
+
+        await token.burn(100,{ from: accounts[1] });
+
+        amount = await token.balanceOf(accounts[1]);
+
+        assert.equal(amount.toNumber(), 900);
+
+        const totalSupply = await token.totalSupply();
+
+        assert.equal(totalSupply.toNumber(), 900);
+    });
+
     describe('onlyOwner', () => {
         it('mint by owner', async () => {
             const token = await DAOToken.new();


### PR DESCRIPTION
- Remove lock functionality from daotoken .
- This functionality will be implemented at "MarinaToken" See issue #169 
- Make daotoken burnable
-Add burn test
