### PR TITLE
Bump version to 17

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "daostack-arc",
-  "version": "0.0.0-alpha.16",
+  "version": "0.0.0-alpha.17",
   "description": "Building DAOs",
   "main": "dist/arc.js",
   "types": "lib/arc.d.ts",


### PR DESCRIPTION
I would like to publish the latest so I can also potentially publish it in arc-js, or at minimum, include it in the currently-outstanding PR.