### PR TITLE
bumped node version to at least 9.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "arc"
   ],
   "engines": {
-    "node": ">=8.0.0"
+    "node": ">=9.4.0"
   },
   "authors": [
     "Adam Levi <adam@daostack.io>",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "arc"
   ],
   "engines": {
-    "node": ">=9.4.0"
+    "node": ">=9.3.0"
   },
   "authors": [
     "Adam Levi <adam@daostack.io>",


### PR DESCRIPTION
to support `es6` syntax.